### PR TITLE
Cross screen communication with ViewModels

### DIFF
--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/domain/Category.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/domain/Category.kt
@@ -1,0 +1,10 @@
+package com.lucianbc.receiptscan.v2.domain
+
+enum class Category {
+    NotAssigned,
+    Grocery,
+    Coffee,
+    Transportation,
+    Restaurant,
+    Snack
+}

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/Navigation.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/Navigation.kt
@@ -32,7 +32,8 @@ fun Navigation() {
             CategoriesScreen(params, vm)
         }
         composable("currencies") {
-            CurrenciesScreen(params)
+            val vm = it.parentViewModel<HomeViewModelImpl>(controller = controller)
+            CurrenciesScreen(params, vm)
         }
         composable("transaction") {
             ReceiptScreen()

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/Navigation.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/Navigation.kt
@@ -3,6 +3,10 @@ package com.lucianbc.receiptscan.v2.ui
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.get
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -10,6 +14,7 @@ import androidx.navigation.compose.navigate
 import androidx.navigation.compose.rememberNavController
 import com.lucianbc.receiptscan.v2.ui.components.NavigationBarParams
 import com.lucianbc.receiptscan.v2.ui.screens.*
+import com.lucianbc.receiptscan.v2.ui.viewModels.HomeViewModelImpl
 
 @ExperimentalFoundationApi
 @Composable
@@ -19,10 +24,12 @@ fun Navigation() {
 
     NavHost(navController = controller, startDestination = "home") {
         composable("home") {
-            HomeScreen(params)
+            val vm = it.parentViewModel<HomeViewModelImpl>(controller = controller)
+            HomeScreen(params, vm)
         }
         composable("categories") {
-            CategoriesScreen(params)
+            val vm = it.parentViewModel<HomeViewModelImpl>(controller = controller)
+            CategoriesScreen(params, vm)
         }
         composable("currencies") {
             CurrenciesScreen(params)
@@ -31,6 +38,14 @@ fun Navigation() {
             ReceiptScreen()
         }
     }
+}
+
+@Composable
+inline fun <reified T : ViewModel> NavBackStackEntry.parentViewModel(controller: NavController): T {
+    val parentEntry = checkNotNull(destination.parent?.id?.let(controller::getBackStackEntry)) {
+        "Cannot build parent view model because no backstack entry was found for the parent nav graph"
+    }
+    return ViewModelProvider(parentEntry).get()
 }
 
 private val createParams = { controller: NavController ->

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -28,12 +30,14 @@ import com.lucianbc.receiptscan.v2.ui.viewModels.CategoriesViewModel
 @ExperimentalFoundationApi
 @Composable
 fun CategoriesScreen(params: NavigationBarParams, viewModel: CategoriesViewModel) {
+    val categories by viewModel.categories.collectAsState()
+
     Screen {
         TitleBar(title = "Categories", backEnabled = true, params = params)
         LazyVerticalGrid(
             cells = GridCells.Fixed(2)
         ) {
-            items(Category.values()) {
+            items(categories) {
                 CategoryItem(it) {
                     viewModel.setCategory(it)
                     params.goBack()

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
@@ -25,14 +25,17 @@ import com.lucianbc.receiptscan.v2.ui.components.TitleBar
 
 @ExperimentalFoundationApi
 @Composable
-fun CategoriesScreen(params: NavigationBarParams) {
+fun CategoriesScreen(params: NavigationBarParams, settingsViewModel: SettingsViewModel) {
     Screen {
         TitleBar(title = "Categories", backEnabled = true, params = params)
         LazyVerticalGrid(
             cells = GridCells.Fixed(2)
         ) {
             items(Category.values()) {
-                CategoryItem(it)
+                CategoryItem(it) {
+                    settingsViewModel.updateCategory(it)
+                    params.goBack()
+                }
             }
         }
     }
@@ -40,10 +43,10 @@ fun CategoriesScreen(params: NavigationBarParams) {
 
 
 @Composable
-fun CategoryItem(category: Category) {
+fun CategoryItem(category: Category, onClick: OnClick) {
     Column(
         modifier = Modifier
-            .clickable { }
+            .clickable { onClick?.invoke() }
             .padding(vertical = 16.dp, horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -95,5 +98,5 @@ fun Category.icon(): Int {
 @Preview
 @Composable
 fun CategoriesScreenPreview() {
-    CategoriesScreen(NavigationBarParams.Empty)
+    CategoriesScreen(NavigationBarParams.Empty, SettingsViewModel.Empty)
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CategoriesScreen.kt
@@ -18,14 +18,16 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lucianbc.receiptscan.v2.R
+import com.lucianbc.receiptscan.v2.domain.Category
 import com.lucianbc.receiptscan.v2.ui.components.NavigationBarParams
 import com.lucianbc.receiptscan.v2.ui.components.Screen
 import com.lucianbc.receiptscan.v2.ui.components.TitleBar
+import com.lucianbc.receiptscan.v2.ui.viewModels.CategoriesViewModel
 
 
 @ExperimentalFoundationApi
 @Composable
-fun CategoriesScreen(params: NavigationBarParams, settingsViewModel: SettingsViewModel) {
+fun CategoriesScreen(params: NavigationBarParams, viewModel: CategoriesViewModel) {
     Screen {
         TitleBar(title = "Categories", backEnabled = true, params = params)
         LazyVerticalGrid(
@@ -33,7 +35,7 @@ fun CategoriesScreen(params: NavigationBarParams, settingsViewModel: SettingsVie
         ) {
             items(Category.values()) {
                 CategoryItem(it) {
-                    settingsViewModel.updateCategory(it)
+                    viewModel.setCategory(it)
                     params.goBack()
                 }
             }
@@ -74,15 +76,6 @@ fun CategoryAvatar(category: Category, size: Int = 80, padding: Int = 16) {
     )
 }
 
-enum class Category {
-    NotAssigned,
-    Grocery,
-    Coffee,
-    Transportation,
-    Restaurant,
-    Snack
-}
-
 fun Category.icon(): Int {
     return when (this) {
         Category.NotAssigned -> R.drawable.ic_coin_24dp
@@ -98,5 +91,5 @@ fun Category.icon(): Int {
 @Preview
 @Composable
 fun CategoriesScreenPreview() {
-    CategoriesScreen(NavigationBarParams.Empty, SettingsViewModel.Empty)
+    CategoriesScreen(NavigationBarParams.Empty, CategoriesViewModel.Empty)
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CurrenciesScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CurrenciesScreen.kt
@@ -9,22 +9,29 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lucianbc.receiptscan.v2.ui.components.NavigationBarParams
 import com.lucianbc.receiptscan.v2.ui.components.Screen
 import com.lucianbc.receiptscan.v2.ui.components.TitleBar
+import com.lucianbc.receiptscan.v2.ui.viewModels.CurrenciesViewModel
 import java.util.*
 
+
 @Composable
-fun CurrenciesScreen(params: NavigationBarParams) {
+fun CurrenciesScreen(params: NavigationBarParams, viewModel: CurrenciesViewModel) {
+    val currencies by viewModel.currencies.collectAsState()
     Screen {
         TitleBar(title = "Currencies", params = params, backEnabled = true)
         LazyColumn {
-            itemsIndexed(Currency.getAvailableCurrencies().toList()) { _, it ->
-                CurrencyListItem(currency = it) {}
-
+            itemsIndexed(currencies) { _, it ->
+                CurrencyListItem(currency = it) {
+                    viewModel.setCurrency(it)
+                    params.goBack()
+                }
             }
         }
     }
@@ -52,4 +59,5 @@ fun CurrencyListItem(currency: Currency, onClick: OnClick) {
 
 @Preview
 @Composable
-fun CurrenciesScreenPreview() = CurrenciesScreen(params = NavigationBarParams.Empty)
+fun CurrenciesScreenPreview() =
+    CurrenciesScreen(params = NavigationBarParams.Empty, CurrenciesViewModel.Empty)

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CurrenciesScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/CurrenciesScreen.kt
@@ -1,10 +1,17 @@
 package com.lucianbc.receiptscan.v2.ui.screens
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.lucianbc.receiptscan.v2.ui.components.NavigationBarParams
 import com.lucianbc.receiptscan.v2.ui.components.Screen
 import com.lucianbc.receiptscan.v2.ui.components.TitleBar
@@ -16,9 +23,30 @@ fun CurrenciesScreen(params: NavigationBarParams) {
         TitleBar(title = "Currencies", params = params, backEnabled = true)
         LazyColumn {
             itemsIndexed(Currency.getAvailableCurrencies().toList()) { _, it ->
-                Text(it.displayName)
+                CurrencyListItem(currency = it) {}
+
             }
         }
+    }
+}
+
+@Composable
+fun CurrencyListItem(currency: Currency, onClick: OnClick) {
+    val biggerPadding = 16.dp
+    val smallerPadding = 8.dp
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .clickable { onClick?.invoke() }
+        .padding(
+            top = biggerPadding,
+            start = biggerPadding,
+            end = biggerPadding,
+            bottom = smallerPadding
+        )
+
+    ) {
+        Text(text = currency.currencyCode, style = MaterialTheme.typography.h6)
+        Text(text = currency.displayName, style = MaterialTheme.typography.body2)
     }
 }
 

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/HomeScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/HomeScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.tooling.preview.Preview
 import com.lucianbc.receiptscan.v2.ui.components.BottomNavigationView
+import com.lucianbc.receiptscan.v2.ui.viewModels.SettingsViewModel
 
 interface HomeScreenParams : SettingsScreenParams, TransactionsScreenParams {
     companion object Empty : HomeScreenParams by Empty

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/HomeScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/HomeScreen.kt
@@ -15,7 +15,7 @@ interface HomeScreenParams : SettingsScreenParams, TransactionsScreenParams {
 }
 
 @Composable
-fun HomeScreen(params: HomeScreenParams) {
+fun HomeScreen(params: HomeScreenParams, viewModel: SettingsViewModel) {
     BottomNavigationView {
         item("Home", rememberVectorPainter(image = Icons.Default.Home)) {
             TransactionsScreen(params)
@@ -24,7 +24,7 @@ fun HomeScreen(params: HomeScreenParams) {
             DraftsScreen()
         }
         item("Settings", rememberVectorPainter(image = Icons.Default.Settings)) {
-            SettingsScreen(params)
+            SettingsScreen(params, viewModel)
         }
         item("Exports", rememberVectorPainter(image = Icons.Default.KeyboardArrowUp)) {
             ExportsScreen()
@@ -35,4 +35,4 @@ fun HomeScreen(params: HomeScreenParams) {
 
 @Preview(showBackground = true)
 @Composable
-fun HomeScreenPreview() = HomeScreen(HomeScreenParams)
+fun HomeScreenPreview() = HomeScreen(HomeScreenParams, SettingsViewModel.Empty)

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/ReceiptScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/ReceiptScreen.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import com.lucianbc.receiptscan.v2.ui.components.Screen
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.lucianbc.receiptscan.v2.domain.Category
+import com.lucianbc.receiptscan.v2.ui.components.Screen
 import java.text.SimpleDateFormat
 import java.util.*
 

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,17 +31,22 @@ interface SettingsScreenParams {
 
 @Composable
 fun SettingsScreen(params: SettingsScreenParams, viewModel: SettingsViewModel) {
-    var enabled by remember { mutableStateOf(false) }
-    val defaultCategory by viewModel.defaultCategory.collectAsState()
+    val viewState by viewModel.settingsState.collectAsState()
+    
     Screen(title = "Settings") {
-        SettingRow(key = "Default Currency", value = "RON", params::goToCurrencies)
+        SettingRow(
+            key = "Default Currency",
+            value = viewState.defaultCurrency.currencyCode,
+            params::goToCurrencies,
+        )
         SettingRow(
             key = "Default Category",
-            value = defaultCategory.name,
-            params::goToCategories
+            value = viewState.defaultCategory.name,
+            params::goToCategories,
         )
         SettingRow(key = "Send Receipt Anonymously") {
-            Switch(checked = enabled, onCheckedChange = { enabled = !enabled })
+            Switch(checked = viewState.shareAnonymousData,
+                onCheckedChange = { viewModel.toggleSendReceiptAnonymously() })
         }
     }
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lucianbc.receiptscan.v2.ui.components.Screen
+import com.lucianbc.receiptscan.v2.ui.viewModels.SettingsViewModel
 
 
 interface SettingsScreenParams {
@@ -26,26 +27,15 @@ interface SettingsScreenParams {
     }
 }
 
-interface SettingsViewModel {
-    val defaultCategory: State<Category>
-    fun updateCategory(category: Category)
-
-    companion object Empty : SettingsViewModel {
-        override val defaultCategory: State<Category>
-            get() = derivedStateOf { Category.Restaurant }
-
-        override fun updateCategory(category: Category) {}
-    }
-}
-
 @Composable
 fun SettingsScreen(params: SettingsScreenParams, viewModel: SettingsViewModel) {
     var enabled by remember { mutableStateOf(false) }
+    val defaultCategory by viewModel.defaultCategory.collectAsState()
     Screen(title = "Settings") {
         SettingRow(key = "Default Currency", value = "RON", params::goToCurrencies)
         SettingRow(
             key = "Default Category",
-            value = viewModel.defaultCategory.value.name,
+            value = defaultCategory.name,
             params::goToCategories
         )
         SettingRow(key = "Send Receipt Anonymously") {

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
@@ -20,12 +20,9 @@ interface SettingsScreenParams {
     fun goToCategories()
     fun goToCurrencies()
 
-    val defaultCategory: State<Category>
-
     object Empty : SettingsScreenParams {
         override fun goToCategories() {}
         override fun goToCurrencies() {}
-        override val defaultCategory: State<Category> = derivedStateOf { Category.Restaurant }
     }
 }
 

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/SettingsScreen.kt
@@ -7,11 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,18 +20,37 @@ interface SettingsScreenParams {
     fun goToCategories()
     fun goToCurrencies()
 
+    val defaultCategory: State<Category>
+
     object Empty : SettingsScreenParams {
         override fun goToCategories() {}
         override fun goToCurrencies() {}
+        override val defaultCategory: State<Category> = derivedStateOf { Category.Restaurant }
+    }
+}
+
+interface SettingsViewModel {
+    val defaultCategory: State<Category>
+    fun updateCategory(category: Category)
+
+    companion object Empty : SettingsViewModel {
+        override val defaultCategory: State<Category>
+            get() = derivedStateOf { Category.Restaurant }
+
+        override fun updateCategory(category: Category) {}
     }
 }
 
 @Composable
-fun SettingsScreen(params: SettingsScreenParams) {
+fun SettingsScreen(params: SettingsScreenParams, viewModel: SettingsViewModel) {
     var enabled by remember { mutableStateOf(false) }
     Screen(title = "Settings") {
         SettingRow(key = "Default Currency", value = "RON", params::goToCurrencies)
-        SettingRow(key = "Default Category", value = "Grocery", params::goToCategories)
+        SettingRow(
+            key = "Default Category",
+            value = viewModel.defaultCategory.value.name,
+            params::goToCategories
+        )
         SettingRow(key = "Send Receipt Anonymously") {
             Switch(checked = enabled, onCheckedChange = { enabled = !enabled })
         }
@@ -68,5 +83,5 @@ fun SettingRow(key: String, value: String, onClick: OnClick = null) {
 @Composable
 @Preview
 fun SettingsScreenPreview() {
-    SettingsScreen(SettingsScreenParams.Empty)
+    SettingsScreen(SettingsScreenParams.Empty, SettingsViewModel.Empty)
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/TransactionsScreen.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/screens/TransactionsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.lucianbc.receiptscan.v2.R
+import com.lucianbc.receiptscan.v2.domain.Category
 import com.lucianbc.receiptscan.v2.ui.components.ExpenseListItem
 import com.lucianbc.receiptscan.v2.ui.components.Screen
 

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CategoriesViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CategoriesViewModel.kt
@@ -1,0 +1,17 @@
+package com.lucianbc.receiptscan.v2.ui.viewModels
+
+import com.lucianbc.receiptscan.v2.domain.Category
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface CategoriesViewModel {
+    val categories: StateFlow<List<Category>>
+    fun setCategory(category: Category)
+
+    object Empty : CategoriesViewModel {
+        override val categories: StateFlow<List<Category>> =
+            MutableStateFlow(Category.values().toList())
+
+        override fun setCategory(category: Category) {}
+    }
+}

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CollectDataViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CollectDataViewModel.kt
@@ -1,0 +1,5 @@
+package com.lucianbc.receiptscan.v2.ui.viewModels
+
+interface CollectDataViewModel {
+    fun toggleSendReceiptAnonymously()
+}

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CurrenciesViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/CurrenciesViewModel.kt
@@ -1,0 +1,17 @@
+package com.lucianbc.receiptscan.v2.ui.viewModels
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.util.*
+
+interface CurrenciesViewModel {
+    val currencies: StateFlow<List<Currency>>
+    fun setCurrency(currency: Currency)
+
+    object Empty : CurrenciesViewModel {
+        override val currencies: StateFlow<List<Currency>> =
+            MutableStateFlow(Currency.getAvailableCurrencies().toList())
+
+        override fun setCurrency(currency: Currency) {}
+    }
+}

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
@@ -1,0 +1,17 @@
+package com.lucianbc.receiptscan.v2.ui.viewModels
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.lucianbc.receiptscan.v2.ui.screens.Category
+import com.lucianbc.receiptscan.v2.ui.screens.SettingsViewModel
+
+class HomeViewModelImpl : ViewModel(), SettingsViewModel {
+    private val categoryMutable = mutableStateOf(Category.Restaurant)
+
+    override val defaultCategory: State<Category> = categoryMutable
+
+    override fun updateCategory(category: Category) {
+        categoryMutable.value = category
+    }
+}

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
@@ -9,7 +9,8 @@ import java.util.*
 class HomeViewModelImpl : ViewModel(),
     SettingsViewModel,
     CategoriesViewModel,
-    CollectDataViewModel {
+    CollectDataViewModel,
+    CurrenciesViewModel {
 
     override val categories: StateFlow<List<Category>> =
         MutableStateFlow(Category.values().toList())
@@ -21,7 +22,7 @@ class HomeViewModelImpl : ViewModel(),
             false,
         )
     )
-
+    
     override val settingsState: StateFlow<SettingsViewModel.ViewState> = _settingsState
 
     override fun setCategory(category: Category) {
@@ -31,5 +32,12 @@ class HomeViewModelImpl : ViewModel(),
     override fun toggleSendReceiptAnonymously() {
         _settingsState.value =
             _settingsState.value.run { copy(shareAnonymousData = !shareAnonymousData) }
+    }
+
+    override val currencies: StateFlow<List<Currency>> =
+        MutableStateFlow(Currency.getAvailableCurrencies().toList())
+
+    override fun setCurrency(currency: Currency) {
+        _settingsState.value = _settingsState.value.run { copy(defaultCurrency = currency) }
     }
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
@@ -1,17 +1,19 @@
 package com.lucianbc.receiptscan.v2.ui.viewModels
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
-import com.lucianbc.receiptscan.v2.ui.screens.Category
-import com.lucianbc.receiptscan.v2.ui.screens.SettingsViewModel
+import com.lucianbc.receiptscan.v2.domain.Category
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
-class HomeViewModelImpl : ViewModel(), SettingsViewModel {
-    private val categoryMutable = mutableStateOf(Category.Restaurant)
+class HomeViewModelImpl : ViewModel(), SettingsViewModel, CategoriesViewModel {
+    private val _defaultCategory = MutableStateFlow(Category.NotAssigned)
 
-    override val defaultCategory: State<Category> = categoryMutable
+    override val defaultCategory = _defaultCategory
 
-    override fun updateCategory(category: Category) {
-        categoryMutable.value = category
+    override val categories: StateFlow<List<Category>> =
+        MutableStateFlow(Category.values().toList())
+
+    override fun setCategory(category: Category) {
+        _defaultCategory.value = category
     }
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/HomeViewModel.kt
@@ -4,16 +4,32 @@ import androidx.lifecycle.ViewModel
 import com.lucianbc.receiptscan.v2.domain.Category
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.*
 
-class HomeViewModelImpl : ViewModel(), SettingsViewModel, CategoriesViewModel {
-    private val _defaultCategory = MutableStateFlow(Category.NotAssigned)
-
-    override val defaultCategory = _defaultCategory
+class HomeViewModelImpl : ViewModel(),
+    SettingsViewModel,
+    CategoriesViewModel,
+    CollectDataViewModel {
 
     override val categories: StateFlow<List<Category>> =
         MutableStateFlow(Category.values().toList())
 
+    private val _settingsState = MutableStateFlow(
+        SettingsViewModel.ViewState(
+            Category.NotAssigned,
+            Currency.getInstance("RON"),
+            false,
+        )
+    )
+
+    override val settingsState: StateFlow<SettingsViewModel.ViewState> = _settingsState
+
     override fun setCategory(category: Category) {
-        _defaultCategory.value = category
+        _settingsState.value = _settingsState.value.copy(defaultCategory = category)
+    }
+
+    override fun toggleSendReceiptAnonymously() {
+        _settingsState.value =
+            _settingsState.value.run { copy(shareAnonymousData = !shareAnonymousData) }
     }
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/SettingsViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/SettingsViewModel.kt
@@ -3,11 +3,26 @@ package com.lucianbc.receiptscan.v2.ui.viewModels
 import com.lucianbc.receiptscan.v2.domain.Category
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.*
 
-interface SettingsViewModel {
-    val defaultCategory: StateFlow<Category>
+interface SettingsViewModel : CollectDataViewModel {
+    val settingsState: StateFlow<ViewState>
 
     object Empty : SettingsViewModel {
-        override val defaultCategory: StateFlow<Category> = MutableStateFlow(Category.Restaurant)
+        override val settingsState: StateFlow<ViewState> = MutableStateFlow(
+            ViewState(
+                Category.Restaurant,
+                Currency.getInstance("RON"),
+                true
+            )
+        )
+
+        override fun toggleSendReceiptAnonymously() {}
     }
+
+    data class ViewState(
+        val defaultCategory: Category,
+        val defaultCurrency: Currency,
+        val shareAnonymousData: Boolean,
+    )
 }

--- a/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/SettingsViewModel.kt
+++ b/v2/src/main/java/com/lucianbc/receiptscan/v2/ui/viewModels/SettingsViewModel.kt
@@ -1,0 +1,13 @@
+package com.lucianbc.receiptscan.v2.ui.viewModels
+
+import com.lucianbc.receiptscan.v2.domain.Category
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface SettingsViewModel {
+    val defaultCategory: StateFlow<Category>
+
+    object Empty : SettingsViewModel {
+        override val defaultCategory: StateFlow<Category> = MutableStateFlow(Category.Restaurant)
+    }
+}


### PR DESCRIPTION
- Implements the Currencies Screen
- Adds a few interfaces to help isolate different concerns. The currencies and categories screen is meant to be re-used, so having these fine-grained interfaces will make it easier to implement more viewModels that implement them and re-use the UI
- Implements the `parentViewModel` utility to help scope the a viewModel to a parent navigation component. This is useful because we want to scope all settings-related data to the lifecycle of the settings tab. 

Closes #28 